### PR TITLE
#38 The opacity button does not update with the current element

### DIFF
--- a/src/editor/svgedit.js
+++ b/src/editor/svgedit.js
@@ -596,6 +596,8 @@ class Editor extends EditorStartup {
 
     // All elements including image and group have opacity
     if (!isNullish(this.selectedElement)) {
+      const opacPerc = (this.selectedElement.getAttribute('opacity') || 1.0) * 100;
+      $id('opacity').value = opacPerc;
       $id('elem_id').value = this.selectedElement.id;
       $id('elem_class').value =
         (this.selectedElement.getAttribute('class') !== null) ? this.selectedElement.getAttribute('class') : '';


### PR DESCRIPTION
## PR description

The opacity button does not update with the current element (for example, below it is always 100 but it should be 70 on the second image)